### PR TITLE
Replace outdated HttpWebRequest with HttpClient

### DIFF
--- a/ShareFileModule-Installer/Globals.wxi
+++ b/ShareFileModule-Installer/Globals.wxi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
-  <?define Version = "1.0.0.0" ?>
+  <?define Version = "1.0.1.0" ?>
   <?define Description = "PowerShell Module for ShareFile API. Version $(var.Version)" ?>
   <?define Vendor = "Progress ShareFile" ?>
   <?define SourceRootPath = "..\ShareFileModule\bin\Release\net48" ?>

--- a/ShareFileModule/ShareFileModule.csproj
+++ b/ShareFileModule/ShareFileModule.csproj
@@ -2,12 +2,13 @@
   <PropertyGroup>
     <RootNamespace>ShareFile.Api.Powershell</RootNamespace>
     <TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
     <AssemblyTitle>ShareFileModule</AssemblyTitle>
     <Product>ShareFileModule</Product>
-    <Copyright>Copyright © 2024 Progress</Copyright>
+    <Copyright>Copyright © 2025 Progress</Copyright>
     <Deterministic>false</Deterministic>
-    <AssemblyVersion>1.0.*</AssemblyVersion>
-    <FileVersion>1.0.*</FileVersion>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <UseWindowsForms>true</UseWindowsForms>
 	<!-- For Dispatcher found in System.Windows.Threading -->


### PR DESCRIPTION
Replace deprecated `HttpWebRequest` instances with `HttpClient`.
The Net framework implementation is less clean as HttpClient is missing synchronous methods.