### PR TITLE
Update namespaces

### DIFF
--- a/Samples/AutoArchiveFiles.ps1
+++ b/Samples/AutoArchiveFiles.ps1
@@ -45,7 +45,7 @@ $fileParent = '{
 
 #Once we have the files we move them
 foreach($file in $files){
-    if ($file.GetType().ToString() -eq "ShareFile.Api.Models.File"){
+    if ($file.GetType().ToString() -eq "ShareFile.Api.Client.Models.File"){
         Send-SfRequest -Client $sfClient -Entity Items -Method PATCH -Id $file.Id.ToString() -BodyText $fileParent
     }
 }

--- a/Samples/CreateUsers.ps1
+++ b/Samples/CreateUsers.ps1
@@ -10,7 +10,7 @@ foreach ($contact in $contacts)
     if ($contact.'E-mail Address' -and $contact.'First Name' -and $contact.'Last Name')
     {
         #create contact in ShareFile
-        $user = New-Object ShareFile.Api.Models.User
+        $user = New-Object ShareFile.Api.Client.Models.User
 
         #required fields
         $user.FirstName = $contact.'First Name'

--- a/Samples/DeleteMostRecent.ps1
+++ b/Samples/DeleteMostRecent.ps1
@@ -68,7 +68,7 @@ Function CheckVersions($FolderRoot, $Dateofincident){
              
             # Write-Host "date of upload " $item.creationdate
             # Check if Item is a file
-            if ($item.__type -eq "ShareFile.Api.Models.File"){
+            if ($item.__type -eq "ShareFile.Api.Client.Models.File"){
  
                 # If there are multiple versions and the date of upload was within the 1 day span of infection
                 if (($item.HasMultipleVersions -eq "true") -and ($time.days -le 1)) {
@@ -83,7 +83,7 @@ Function CheckVersions($FolderRoot, $Dateofincident){
             } 
  
             # Item is a Folder; send back to CheckVersions
-            if ($item.__type -eq "ShareFile.Api.Models.Folder"){
+            if ($item.__type -eq "ShareFile.Api.Client.Models.Folder"){
                 $newRoot = Send-SfRequest -client $client -Entity Items -Id $item.id -expand "Children"
                 CheckVersions $newRoot $Dateofincident
             }

--- a/Samples/StorageReport.ps1
+++ b/Samples/StorageReport.ps1
@@ -31,7 +31,7 @@ function GetFileSize($ItemID, $ItemType)
     foreach ($item in $Items.Children)
     {
         #since folders return a 'file size' of all the children ignore unless it is a file
-        if ($item.__type -eq "ShareFile.Api.Models.File")
+        if ($item.__type -eq "ShareFile.Api.Client.Models.File")
         {
             #CREATE A HASTHATBLE WITH ID/NAME
             #LOOKUP WITH PATH AND ADD FROM GET IF NOT THERE SO WE ONLY GET ONCE
@@ -70,7 +70,7 @@ function GetFileSize($ItemID, $ItemType)
         }
 
         #determine type of item and recurse if a folder
-        if ($item.__type -eq "ShareFile.Api.Models.Folder") { GetFileSize $item.Id $ItemType}
+        if ($item.__type -eq "ShareFile.Api.Client.Models.Folder") { GetFileSize $item.Id $ItemType}
     }
 }
 

--- a/ShareFileModule/ShareFile.Format.ps1xml
+++ b/ShareFileModule/ShareFile.Format.ps1xml
@@ -4,7 +4,7 @@
     <View>
       <Name>FolderTableView</Name>
       <ViewSelectedBy>
-        <TypeName>ShareFile.Api.Models.Item</TypeName>
+        <TypeName>ShareFile.Api.Client.Models.Item</TypeName>
       </ViewSelectedBy>
       <TableControl>
         <TableHeaders>

--- a/ShareFileModule/ShareFileSnapIn.dll-Help.xml
+++ b/ShareFileModule/ShareFileSnapIn.dll-Help.xml
@@ -391,7 +391,7 @@ Retrieve a previously saved authentication state</maml:title>
         <command:parameter required="false" position="named">
           <maml:name>Body</maml:name>
           <maml:description/>
-          <command:parameterValue>ShareFile.Api.Models.ODataObject</command:parameterValue>
+          <command:parameterValue>ShareFile.Api.Client.Models.ODataObject</command:parameterValue>
         </command:parameter>
 
         <command:parameter required="false" position="named">
@@ -447,7 +447,7 @@ Retrieve a previously saved authentication state</maml:title>
         <maml:description>
           <maml:para>The HTTP Verb used in the operation: GET, POST, PATCH, PUT or  DELETE.</maml:para>
           <maml:para>GET retrieves elements, and do not perform changes in the API server.</maml:para>
-          <maml:para>POST create new elements or relationships. Most POST operations require a Body, which are generally classes of ShareFile.Api.Models namespace (see examples)</maml:para>
+          <maml:para>POST create new elements or relationships. Most POST operations require a Body, which are generally classes of ShareFile.Api.Client.Models namespace (see examples)</maml:para>
           <maml:para>PUT replaces the current element with a new set of values - most ShareFile Entities do not support this Verb - use PATCH by default instead</maml:para>
           <maml:para>PATCH replaces the attribute values provided in the request Body, but leave unspecified attributes unchanged.</maml:para>
           <maml:para>DELETE removes the Entity</maml:para>
@@ -543,7 +543,7 @@ Retrieve a previously saved authentication state</maml:title>
         <maml:description>
           <maml:para>Request Body for the operation. The request body is usually a single or a list of ShareFile.Api.Model objects. (see examples).</maml:para>
         </maml:description>
-        <command:parametervalue required="true">ShareFile.Api.Models.ODataObject</command:parametervalue>
+        <command:parametervalue required="true">ShareFile.Api.Client.Models.ODataObject</command:parametervalue>
         <dev:type>
           <maml:name></maml:name>
           <maml:uri/>
@@ -609,12 +609,12 @@ Retrieve a previously saved authentication state</maml:title>
     <command:returnValues>
       <command:returnValue>
         <dev:type>
-          <maml:name>ShareFile.Api.Models.ODataObject</maml:name>
+          <maml:name>ShareFile.Api.Client.Models.ODataObject</maml:name>
           <maml:uri />
           <maml:description>
             <maml:para>
-              All API responses are deserialized into ShareFile.Api.Model classes, sub-types of ShareFile.Api.Models.ODataObject.
-            </maml:para>
+				All API responses are deserialized into ShareFile.Api.Client.Models classes, sub-types of ShareFile.Api.Client.Models.ODataObject.
+			</maml:para>
           </maml:description>
         </dev:type>
       </command:returnValue>
@@ -646,7 +646,7 @@ $client = New-SfClient -Name acme
 Send-SfRequest -Client $c -Verb GET -Entity Users
         </dev:code>
         <dev:remarks>
-          <maml:para>Return a ShareFile.Api.Models.User object containing attributes of the current user</maml:para>
+          <maml:para>Return a ShareFile.Api.Client.Models.User object containing attributes of the current user</maml:para>
         </dev:remarks>
       </command:example>
 
@@ -669,11 +669,11 @@ Create a new object
         </maml:title>
         <maml:introduction/>
         <dev:code>
-$folder = New-Object ShareFile.Api.Models.Folder
-$folder.Name = "Example Folder"
-$homeFolder = Send-SfRequest -Client $c -Verb GET -Entity Users -Navigation HomeFolder -Select "Id,url"
-Send-SfRequest -Client $c -Verb POST -Uri $homeFolder.url -Body $folder -Cast Folder -Parameters @{ "overwrite"="true" }
-        </dev:code>
+			$folder = New-Object ShareFile.Api.Client.Models.Folder
+			$folder.Name = "Example Folder"
+			$homeFolder = Send-SfRequest -Client $c -Verb GET -Entity Users -Navigation HomeFolder -Select "Id,url"
+			Send-SfRequest -Client $c -Verb POST -Uri $homeFolder.url -Body $folder -Cast Folder -Parameters @{ "overwrite"="true" }
+		</dev:code>
         <dev:remarks>
           <maml:para>Retrieves the current user home folder using the HomeFolder navigation property; then creates a new folder under that.</maml:para>
         </dev:remarks>
@@ -685,12 +685,12 @@ Updates an object
         </maml:title>
         <maml:introduction/>
         <dev:code>
-$folderUpdate = New-Object ShareFile.Api.Models.Folder
-$folder.Name = "Example Folder 2"
-$homeFolder = Send-SfRequest -Client $c -Verb GET -Entity Users -Navigation HomeFolder -Select "Id,url"
-$folderTarget = Send-SfRequest -Client $c -Verb GET -Uri $homeFolder.url -Action ByPath -Parameters @{ "path"="/Example Folder" }
-Send-SfRequest -Client $c -Verb PATCH -Uri $folderTarget.url -Body $folderUpdate 
-        </dev:code>
+			$folderUpdate = New-Object ShareFile.Api.Client.Models.Folder
+			$folder.Name = "Example Folder 2"
+			$homeFolder = Send-SfRequest -Client $c -Verb GET -Entity Users -Navigation HomeFolder -Select "Id,url"
+			$folderTarget = Send-SfRequest -Client $c -Verb GET -Uri $homeFolder.url -Action ByPath -Parameters @{ "path"="/Example Folder" }
+			Send-SfRequest -Client $c -Verb PATCH -Uri $folderTarget.url -Body $folderUpdate
+		</dev:code>
         <dev:remarks>
           <maml:para>Updates the element created in Example 3: retrieves the current user home folder; then finds a named folder under that element using the ByPath action. Then sends an update request to the retrieved folder.</maml:para>
         </dev:remarks>

--- a/Test-ShareFileModule/CopySFItemsTests.cs
+++ b/Test-ShareFileModule/CopySFItemsTests.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.IO;
+﻿using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ShareFile.Api.Powershell;
 
 namespace Test_ShareFileSnapIn
 {
@@ -18,14 +14,7 @@ namespace Test_ShareFileSnapIn
         [TestInitialize]
         public void InitializeTests()
         {
-            RunspaceConfiguration config = RunspaceConfiguration.Create();
-
-            PSSnapInException warning;
-
-            config.AddPSSnapIn("ShareFile", out warning);
-
-            runspace = RunspaceFactory.CreateRunspace(config);
-            runspace.Open();
+            runspace = Utils.OpenRunspace();
 
             // do login first to start tests
             using (Pipeline pipeline = runspace.CreatePipeline())
@@ -56,6 +45,13 @@ namespace Test_ShareFileSnapIn
                 // Drive is successfully mapped to root folder
                 Assert.AreEqual<int>(1, psObjects.Count);
             }
+        }
+
+        [TestCleanup]
+        public void CleanupTests()
+        {
+            runspace?.Dispose();
+            runspace = null;
         }
 
         [TestMethod]
@@ -128,7 +124,7 @@ namespace Test_ShareFileSnapIn
                 Collection<PSObject> psObjects = pipeline.Invoke();
 
                 Assert.AreEqual<int>(1, psObjects.Count);
-                Assert.AreEqual("ShareFile.Api.Models.File", psObjects[0].BaseObject.ToString());
+                Assert.AreEqual("ShareFile.Api.Client.Models.File", psObjects[0].BaseObject.ToString());
             }
         }
 
@@ -160,7 +156,7 @@ namespace Test_ShareFileSnapIn
                 Collection<PSObject> psObjects = pipeline.Invoke();
 
                 Assert.AreEqual<int>(1, psObjects.Count);
-                Assert.AreEqual("ShareFile.Api.Models.File", psObjects[0].BaseObject.ToString());
+                Assert.AreEqual("ShareFile.Api.Client.Models.File", psObjects[0].BaseObject.ToString());
             }
         }
 

--- a/Test-ShareFileModule/LoginTests.cs
+++ b/Test-ShareFileModule/LoginTests.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.ObjectModel;
-using System.IO;
+﻿using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ShareFile.Api.Powershell;
 
 namespace Test_ShareFileSnapIn
 {
@@ -16,31 +13,27 @@ namespace Test_ShareFileSnapIn
         [TestInitialize]
         public void InitializeTests()
         {
-            RunspaceConfiguration config = RunspaceConfiguration.Create();
+            runspace = Utils.OpenRunspace();
+        }
 
-            PSSnapInException warning;
-
-            config.AddPSSnapIn("ShareFile", out warning);
-
-            runspace = RunspaceFactory.CreateRunspace(config);
-            runspace.Open();
+        [TestCleanup]
+        public void CleanupTests()
+        {
+            runspace?.Dispose();
+            runspace = null;
         }
 
         [TestMethod]
         public void TM1_0_NewLoginTest()
         {
-            PowerShell ps = PowerShell.Create();
-
-            ps.AddCommand("Add-PSSnapIn");
-            ps.AddArgument("ShareFile");
-
-            Collection<PSObject> psObjects = ps.Invoke();
+            using var ps = PowerShell.Create();
+            ps.Runspace = runspace;
 
             ps.Commands.Clear();
             ps.AddCommand("New-SFClient");
             ps.AddParameter("Name", Utils.LoginFilePath);
 
-            psObjects = ps.Invoke();
+            var psObjects = ps.Invoke();
 
             Assert.AreEqual<int>(1, psObjects.Count);
         }

--- a/Test-ShareFileModule/MapDriveTests.cs
+++ b/Test-ShareFileModule/MapDriveTests.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ShareFile.Api.Powershell;
 
 namespace Test_ShareFileSnapIn
 {
@@ -17,15 +14,7 @@ namespace Test_ShareFileSnapIn
         [TestInitialize]
         public void InitializeTests()
         {
-
-            RunspaceConfiguration config = RunspaceConfiguration.Create();
-            
-            PSSnapInException warning;
-
-            config.AddPSSnapIn("ShareFile", out warning);
-
-            runspace = RunspaceFactory.CreateRunspace(config);
-            runspace.Open();
+             runspace = Utils.OpenRunspace();
 
             // do login first to start tests
             using (Pipeline pipeline = runspace.CreatePipeline())
@@ -41,7 +30,14 @@ namespace Test_ShareFileSnapIn
                 sfLogin = objs[0];
             }
         }
-        
+
+        [TestCleanup]
+        public void CleanupTests()
+        {
+            runspace?.Dispose();
+            runspace = null;
+        }
+
         [TestMethod]
         public void TM1_MapDriveTest()
         {
@@ -72,7 +68,7 @@ namespace Test_ShareFileSnapIn
             Command command = new Command("New-PSDrive");
             command.Parameters.Add("Name", Utils.ShareFileDriveLetter);
             command.Parameters.Add("PSProvider", "ShareFile");
-            command.Parameters.Add("Root", "/My Files & Folders");
+            command.Parameters.Add("Root", "/");
             command.Parameters.Add("Client", sfLogin);
 
             pipeline.Commands.Add(command);

--- a/Test-ShareFileModule/SyncSFItemsTests.cs
+++ b/Test-ShareFileModule/SyncSFItemsTests.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ShareFile.Api.Powershell;
 
 namespace Test_ShareFileSnapIn
 {
@@ -17,14 +14,7 @@ namespace Test_ShareFileSnapIn
         [TestInitialize]
         public void InitializeTests()
         {
-            RunspaceConfiguration config = RunspaceConfiguration.Create();
-
-            PSSnapInException warning;
-
-            config.AddPSSnapIn("ShareFile", out warning);
-
-            runspace = RunspaceFactory.CreateRunspace(config);
-            runspace.Open();
+            runspace = Utils.OpenRunspace();
 
             // do login first to start tests
             using (Pipeline pipeline = runspace.CreatePipeline())
@@ -55,6 +45,13 @@ namespace Test_ShareFileSnapIn
                 // Drive is successfully mapped to root folder
                 Assert.AreEqual<int>(1, psObjects.Count);
             }
+        }
+
+        [TestCleanup]
+        public void CleanupTests()
+        {
+            runspace?.Dispose();
+            runspace = null;
         }
 
 
@@ -108,7 +105,7 @@ namespace Test_ShareFileSnapIn
                 Utils.DeleteLocalFolder(Utils.LocalFolderDownloaded);
 
                 Command command = new Command("Sync-SfItem");
-                command.Parameters.Add("ShareFilePath", Utils.ShareFileFolder);
+                command.Parameters.Add("ShareFilePath", Utils.ShareFileFolderFullPath);
                 command.Parameters.Add("LocalPath", Utils.LocalBaseFolder);
                 command.Parameters.Add("Download", true);
                 command.Parameters.Add("Recursive", true);
@@ -129,7 +126,7 @@ namespace Test_ShareFileSnapIn
             using (Pipeline pipeline = runspace.CreatePipeline())
             {
                 Command command = new Command("Sync-SfItem");
-                command.Parameters.Add("ShareFilePath", Utils.ShareFileFolder);
+                command.Parameters.Add("ShareFilePath", Utils.ShareFileFolderFullPath);
                 command.Parameters.Add("LocalPath", Utils.LocalBaseFolder);
                 command.Parameters.Add("Download", true);
                 command.Parameters.Add("OverWrite", true);
@@ -152,7 +149,7 @@ namespace Test_ShareFileSnapIn
                 Utils.DeleteLocalFolder(Utils.LocalFolderDownloaded);
 
                 Command command = new Command("Sync-SfItem");
-                command.Parameters.Add("ShareFilePath", Utils.ShareFileFolder);
+                command.Parameters.Add("ShareFilePath", Utils.ShareFileFolderFullPath);
                 command.Parameters.Add("LocalPath", Utils.LocalBaseFolder);
                 command.Parameters.Add("Download", true);
                 command.Parameters.Add("Move", true);
@@ -195,7 +192,7 @@ namespace Test_ShareFileSnapIn
                 Collection<PSObject> psObjects = pipeline.Invoke();
                 
                 Assert.AreEqual<int>(1, psObjects.Count);
-                Assert.AreEqual("ShareFile.Api.Models.File", psObjects[0].BaseObject.ToString());
+                Assert.AreEqual("ShareFile.Api.Client.Models.File", psObjects[0].BaseObject.ToString());
             }
         }
 

--- a/Test-ShareFileModule/Test-ShareFileModule.csproj
+++ b/Test-ShareFileModule/Test-ShareFileModule.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Test_ShareFileSnapIn</RootNamespace>
     <TargetFramework>net48</TargetFramework>
+	<LangVersion>10</LangVersion>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>

--- a/Test-ShareFileModule/Utils.cs
+++ b/Test-ShareFileModule/Utils.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Management.Automation.Runspaces;
+using System.Management.Automation;
 
 namespace Test_ShareFileSnapIn
 {
@@ -12,9 +14,9 @@ namespace Test_ShareFileSnapIn
         private static string _sfFolder = "Folder1Q";
 
         /// <summary>
-        /// C:\sflogin.sfps
+        /// %LOCALAPPDATA%\ShareFile\sflogin.sfps
         /// </summary>
-        public static string LoginFilePath = @"C:\sflogin.sfps";
+        public static string LoginFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ShareFile", "sflogin.sfps");
 
         /// <summary>
         /// sf
@@ -25,20 +27,20 @@ namespace Test_ShareFileSnapIn
         /// </summary>
         public static string ShareFileDrivePath = string.Format("{0}{1}",ShareFileDriveLetter, ":");
         /// <summary>
-        /// sf:/My Files & Folders
+        /// sf:/Personal Folders
         /// </summary>
-        public static string ShareFileHomeFolder = string.Format("{0}{1}", ShareFileDrivePath, "/My Files & Folders");
+        public static string ShareFileHomeFolder = string.Format("{0}{1}", ShareFileDrivePath, "/Personal Folders");
 
         /// <summary>
         /// sf:/Folder1
         /// </summary>
         public static string ShareFileFolder = string.Format("{0}{1}{2}", ShareFileDrivePath, "/", _localFolder);
         /// <summary>
-        /// sf:/My Files & Folders/Folder1Q
+        /// sf:/Personal Folders/Folder1Q
         /// </summary>
         public static string ShareFileFolderUploaded = string.Format("{0}{1}{2}", ShareFileHomeFolder, "/", _sfFolder);
         /// <summary>
-        /// sf:/My Files & Folders/Folder1
+        /// sf:/Personal Folders/Folder1
         /// </summary>
         public static string ShareFileFolderFullPath = string.Format("{0}{1}{2}", ShareFileHomeFolder, "/", _localFolder);
         /// <summary>
@@ -50,28 +52,28 @@ namespace Test_ShareFileSnapIn
         /// </summary>
         public static string ShareFileFileUploaded = string.Format("{0}{1}{2}", ShareFileHomeFolder, "/", _localFile);
         /// <summary>
-        /// sf:/My Files & Folders/DeepText.txt
+        /// sf:/Personal Folders/DeepText.txt
         /// </summary>
         public static string ShareFileFileFullPath = string.Format("{0}{1}{2}", ShareFileHomeFolder, "/", _sfFile);
 
         /// <summary>
-        /// D:\SFTemp
+        /// %LOCALAPPDATA%\ShareFile\SFTemp
         /// </summary>
-        public static string LocalBaseFolder = @"D:\SFTemp";
+        public static string LocalBaseFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ShareFile", "SFTemp");
         /// <summary>
-        /// D:\SFTemp\Folder1Q
+        /// %LOCALAPPDATA%\ShareFile\SFTemp\Folder1Q
         /// </summary>
         public static string LocalFolder = string.Format("{0}{1}{2}", LocalBaseFolder, @"\", _sfFolder);
         /// <summary>
-        /// D:\SFTemp\Folder1
+        /// %LOCALAPPDATA%\ShareFile\SFTemp\Folder1
         /// </summary>
         public static string LocalFolderDownloaded = string.Format("{0}{1}{2}", LocalBaseFolder, @"\", _localFolder);
         /// <summary>
-        /// D:\SFTemp\ToUpload.txt
+        /// %LOCALAPPDATA%\ShareFile\SFTemp\ToUpload.txt
         /// </summary>
         public static string LocalFile = string.Format("{0}{1}{2}", LocalBaseFolder, @"\", _localFile);
         /// <summary>
-        /// D:\SFTemp\DeepText.txt
+        /// %LOCALAPPDATA%\ShareFile\SFTemp\DeepText.txt
         /// </summary>
         public static string LocalFileDownloaded = string.Format("{0}{1}{2}", LocalBaseFolder, @"\", _sfFile);
         
@@ -113,6 +115,16 @@ namespace Test_ShareFileSnapIn
                 DirectoryInfo directory = new DirectoryInfo(path);
                 DeleteLocalItemRecursive(directory);
             }
+        }
+
+        public static Runspace OpenRunspace()
+        {
+            const string moduleName = "ShareFile";
+            InitialSessionState initial = InitialSessionState.CreateDefault();
+            initial.ImportPSModule(new string[] { moduleName });
+            var runspace = RunspaceFactory.CreateRunspace(initial);
+            runspace.Open();
+            return runspace;
         }
 
         private static void DeleteLocalItemRecursive(FileSystemInfo source)


### PR DESCRIPTION
In the C# SDK, the model namespaces changed with the latest version from ShareFile.Api.Models.* to ShareFile.Api.Clients.Models.*.

Also updated unit tests to fix them.