### PR TITLE
fix: Replace $item.__type with $item.GetType().ToString() in samples

### DIFF
--- a/Samples/DeleteMostRecent.ps1
+++ b/Samples/DeleteMostRecent.ps1
@@ -68,7 +68,7 @@ Function CheckVersions($FolderRoot, $Dateofincident){
              
             # Write-Host "date of upload " $item.creationdate
             # Check if Item is a file
-            if ($item.__type -eq "ShareFile.Api.Client.Models.File"){
+            if ($item.GetType().ToString() -eq "ShareFile.Api.Client.Models.File"){
  
                 # If there are multiple versions and the date of upload was within the 1 day span of infection
                 if (($item.HasMultipleVersions -eq "true") -and ($time.days -le 1)) {
@@ -83,7 +83,7 @@ Function CheckVersions($FolderRoot, $Dateofincident){
             } 
  
             # Item is a Folder; send back to CheckVersions
-            if ($item.__type -eq "ShareFile.Api.Client.Models.Folder"){
+            if ($item.GetType().ToString() -eq "ShareFile.Api.Client.Models.Folder"){
                 $newRoot = Send-SfRequest -client $client -Entity Items -Id $item.id -expand "Children"
                 CheckVersions $newRoot $Dateofincident
             }

--- a/Samples/StorageReport.ps1
+++ b/Samples/StorageReport.ps1
@@ -31,7 +31,7 @@ function GetFileSize($ItemID, $ItemType)
     foreach ($item in $Items.Children)
     {
         #since folders return a 'file size' of all the children ignore unless it is a file
-        if ($item.__type -eq "ShareFile.Api.Client.Models.File")
+        if ($item.GetType().ToString() -eq "ShareFile.Api.Client.Models.File")
         {
             #CREATE A HASTHATBLE WITH ID/NAME
             #LOOKUP WITH PATH AND ADD FROM GET IF NOT THERE SO WE ONLY GET ONCE
@@ -70,7 +70,7 @@ function GetFileSize($ItemID, $ItemType)
         }
 
         #determine type of item and recurse if a folder
-        if ($item.__type -eq "ShareFile.Api.Client.Models.Folder") { GetFileSize $item.Id $ItemType}
+        if ($item.GetType().ToString() -eq "ShareFile.Api.Client.Models.Folder") { GetFileSize $item.Id $ItemType}
     }
 }
 


### PR DESCRIPTION
`$item.GetType().ToString()` will use the `ShareFile.Api.Client.Models.*` namespace, while `$item.__type` uses the `ShareFile.Api.Models.*` namespace.